### PR TITLE
[Automation] Bump Microsoft version to 1.24.1-6

### DIFF
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN \
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG SECURITY_VERSION=-1
+ARG SECURITY_VERSION=-6
 ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-arm64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=73b1befea457d5967632b2b0b93f8d2c0d899d5b6fbd1396c55d0a015292608b

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -33,7 +33,7 @@ RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG SECURITY_VERSION=-1
+ARG SECURITY_VERSION=-6
 ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-amd64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=b0ca85ecc435a93e2ddb626dd9ef7fb6689700a0847b0392eb3e146345a8dea0


### PR DESCRIPTION


See https://github.com/microsoft/go/releases/v1.24.1-6


---



<Actions>
    <action id="a97e8ebb0cd2b13f0766a495c3fbbf8f0cf983259470b64e31d1a4f81842ab89">
        <h3>Bump golang-microsoft to latest version</h3>
        <details id="226c7073ca2786d439fbbe0bf13d2b5523040d4801dfca93d49ece1280917dd3">
            <summary>Update go version 1.24.1-6</summary>
            <p>ran shell command &#34;.github/updatecli.d/bump-go-microsoft-version.sh 1.24.1-6&#34;</p>
            <details>
                <summary>1.24.1-6</summary>
                <pre>&#xA;Release published on the 2025-03-12 20:56:46 +0000 UTC at the url https://github.com/microsoft/go/releases/tag/v1.24.1-6&#xA;&#xA;Microsoft build of Go v1.24.1-6&#xD;&#xA;&#xD;&#xA;No changes since v1.24.1-1. This release was run to test infrastructure changes end to end.</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

